### PR TITLE
Migrating from master-slave terminology

### DIFF
--- a/env/Lib/site-packages/boto/elastictranscoder/layer1.py
+++ b/env/Lib/site-packages/boto/elastictranscoder/layer1.py
@@ -118,10 +118,10 @@ class ElasticTranscoderConnection(AWSAuthConnection):
         :type playlists: list
         :param playlists: If you specify a preset in `PresetId` for which the
             value of `Container` is ts (MPEG-TS), Playlists contains
-            information about the master playlists that you want Elastic
+            information about the main playlists that you want Elastic
             Transcoder to create.
-        We recommend that you create only one master playlist. The maximum
-            number of master playlists in a job is 30.
+        We recommend that you create only one main playlist. The maximum
+            number of main playlists in a job is 30.
 
         """
         uri = '/2012-09-25/jobs'

--- a/env/Lib/site-packages/boto/emr/connection.py
+++ b/env/Lib/site-packages/boto/emr/connection.py
@@ -408,8 +408,8 @@ class EmrConnection(AWSQueryConnection):
 
     def run_jobflow(self, name, log_uri=None, ec2_keyname=None,
                     availability_zone=None,
-                    master_instance_type='m1.small',
-                    slave_instance_type='m1.small', num_instances=1,
+                    main_instance_type='m1.small',
+                    subordinate_instance_type='m1.small', num_instances=1,
                     action_on_failure='TERMINATE_JOB_FLOW', keep_alive=False,
                     enable_debugging=False,
                     hadoop_version=None,
@@ -436,11 +436,11 @@ class EmrConnection(AWSQueryConnection):
         :type availability_zone: str
         :param availability_zone: EC2 availability zone of the cluster
 
-        :type master_instance_type: str
-        :param master_instance_type: EC2 instance type of the master
+        :type main_instance_type: str
+        :param main_instance_type: EC2 instance type of the main
 
-        :type slave_instance_type: str
-        :param slave_instance_type: EC2 instance type of the slave nodes
+        :type subordinate_instance_type: str
+        :param subordinate_instance_type: EC2 instance type of the subordinate nodes
 
         :type num_instances: int
         :param num_instances: Number of instances in the Hadoop cluster
@@ -471,7 +471,7 @@ class EmrConnection(AWSQueryConnection):
         :param instance_groups: Optional list of instance groups to
             use when creating this job.
             NB: When provided, this argument supersedes num_instances
-            and master/slave_instance_type.
+            and main/subordinate_instance_type.
 
         :type ami_version: str
         :param ami_version: Amazon Machine Image (AMI) version to use
@@ -526,15 +526,15 @@ class EmrConnection(AWSQueryConnection):
         params.update(common_params)
 
         # NB: according to the AWS API's error message, we must
-        # "configure instances either using instance count, master and
-        # slave instance type or instance groups but not both."
+        # "configure instances either using instance count, main and
+        # subordinate instance type or instance groups but not both."
         #
         # Thus we switch here on the truthiness of instance_groups.
         if not instance_groups:
             # Instance args (the common case)
             instance_params = self._build_instance_count_and_type_args(
-                                                        master_instance_type,
-                                                        slave_instance_type,
+                                                        main_instance_type,
+                                                        subordinate_instance_type,
                                                         num_instances)
             params.update(instance_params)
         else:
@@ -721,15 +721,15 @@ class EmrConnection(AWSQueryConnection):
 
         return params
 
-    def _build_instance_count_and_type_args(self, master_instance_type,
-                                            slave_instance_type, num_instances):
+    def _build_instance_count_and_type_args(self, main_instance_type,
+                                            subordinate_instance_type, num_instances):
         """
-        Takes a master instance type (string), a slave instance type
+        Takes a main instance type (string), a subordinate instance type
         (string), and a number of instances. Returns a comparable dict
         for use in making a RunJobFlow request.
         """
-        params = {'Instances.MasterInstanceType': master_instance_type,
-                  'Instances.SlaveInstanceType': slave_instance_type,
+        params = {'Instances.MainInstanceType': main_instance_type,
+                  'Instances.SubordinateInstanceType': subordinate_instance_type,
                   'Instances.InstanceCount': num_instances}
         return params
 

--- a/env/Lib/site-packages/boto/emr/step.py
+++ b/env/Lib/site-packages/boto/emr/step.py
@@ -132,7 +132,7 @@ class StreamingStep(Step):
         :param output: The output uri
         :type jar: str
         :param jar: The hadoop streaming jar. This can be either a local
-            path on the master node, or an s3:// URI.
+            path on the main node, or an s3:// URI.
         """
         self.name = name
         self.mapper = mapper

--- a/env/Lib/site-packages/boto/kms/layer1.py
+++ b/env/Lib/site-packages/boto/kms/layer1.py
@@ -130,7 +130,7 @@ class KMSConnection(AWSQueryConnection):
 
     def create_alias(self, alias_name, target_key_id):
         """
-        Creates a display name for a customer master key. An alias can
+        Creates a display name for a customer main key. An alias can
         be used to identify a key and should be unique. The console
         enforces a one-to-one mapping between the alias and a key. An
         alias name can contain only alphanumeric characters, forward
@@ -174,7 +174,7 @@ class KMSConnection(AWSQueryConnection):
         #. RevokeGrant
 
         :type key_id: string
-        :param key_id: A unique key identifier for a customer master key. This
+        :param key_id: A unique key identifier for a customer main key. This
             value can be a globally unique identifier, an ARN, or an alias.
 
         :type grantee_principal: string
@@ -222,7 +222,7 @@ class KMSConnection(AWSQueryConnection):
 
     def create_key(self, policy=None, description=None, key_usage=None):
         """
-        Creates a customer master key. Customer master keys can be
+        Creates a customer main key. Customer main keys can be
         used to encrypt small amounts of data (less than 4K) directly,
         but they are most commonly used to encrypt or envelope data
         keys that are then used to encrypt customer data. For more
@@ -306,10 +306,10 @@ class KMSConnection(AWSQueryConnection):
     def describe_key(self, key_id):
         """
         Provides detailed information about the specified customer
-        master key.
+        main key.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master key to be
+        :param key_id: Unique identifier of the customer main key to be
             described. This can be an ARN, an alias, or a globally unique
             identifier.
 
@@ -323,7 +323,7 @@ class KMSConnection(AWSQueryConnection):
         Marks a key as disabled, thereby preventing its use.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master key to be
+        :param key_id: Unique identifier of the customer main key to be
             disabled. This can be an ARN, an alias, or a globally unique
             identifier.
 
@@ -337,7 +337,7 @@ class KMSConnection(AWSQueryConnection):
         Disables rotation of the specified key.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master key for which
+        :param key_id: Unique identifier of the customer main key for which
             rotation is to be disabled. This can be an ARN, an alias, or a
             globally unique identifier.
 
@@ -352,7 +352,7 @@ class KMSConnection(AWSQueryConnection):
         have up to 25 enabled keys at one time.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master key to be
+        :param key_id: Unique identifier of the customer main key to be
             enabled. This can be an ARN, an alias, or a globally unique
             identifier.
 
@@ -363,10 +363,10 @@ class KMSConnection(AWSQueryConnection):
 
     def enable_key_rotation(self, key_id):
         """
-        Enables rotation of the specified customer master key.
+        Enables rotation of the specified customer main key.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master key for which
+        :param key_id: Unique identifier of the customer main key for which
             rotation is to be enabled. This can be an ARN, an alias, or a
             globally unique identifier.
 
@@ -378,11 +378,11 @@ class KMSConnection(AWSQueryConnection):
     def encrypt(self, key_id, plaintext, encryption_context=None,
                 grant_tokens=None):
         """
-        Encrypts plaintext into ciphertext by using a customer master
+        Encrypts plaintext into ciphertext by using a customer main
         key.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master. This can be an
+        :param key_id: Unique identifier of the customer main. This can be an
             ARN, an alias, or the Key ID.
 
         :type plaintext: blob
@@ -420,7 +420,7 @@ class KMSConnection(AWSQueryConnection):
                           grant_tokens=None):
         """
         Generates a secure data key. Data keys are used to encrypt and
-        decrypt data. They are wrapped by customer master keys.
+        decrypt data. They are wrapped by customer main keys.
 
         :type key_id: string
         :param key_id: Unique identifier of the key. This can be an ARN, an
@@ -472,7 +472,7 @@ class KMSConnection(AWSQueryConnection):
                                             number_of_bytes=None,
                                             grant_tokens=None):
         """
-        Returns a key wrapped by a customer master key without the
+        Returns a key wrapped by a customer main key without the
         plaintext copy of that key. To retrieve the plaintext, see
         GenerateDataKey.
 
@@ -651,7 +651,7 @@ class KMSConnection(AWSQueryConnection):
 
     def list_keys(self, limit=None, marker=None):
         """
-        Lists the customer master keys.
+        Lists the customer main keys.
 
         :type limit: integer
         :param limit: Specify this parameter only when paginating results to
@@ -702,7 +702,7 @@ class KMSConnection(AWSQueryConnection):
                    source_encryption_context=None,
                    destination_encryption_context=None, grant_tokens=None):
         """
-        Encrypts data on the server side with a new customer master
+        Encrypts data on the server side with a new customer main
         key without exposing the plaintext of the data on the client
         side. The data is first decrypted and then encrypted. This
         operation can also be used to change the encryption context of

--- a/env/Lib/site-packages/boto/opsworks/layer1.py
+++ b/env/Lib/site-packages/boto/opsworks/layer1.py
@@ -2124,7 +2124,7 @@ class OpsWorksConnection(AWSQueryConnection):
         :param rds_db_instance_arn: The Amazon RDS instance's ARN.
 
         :type db_user: string
-        :param db_user: The database's master user name.
+        :param db_user: The database's main user name.
 
         :type db_password: string
         :param db_password: The database password.
@@ -2785,7 +2785,7 @@ class OpsWorksConnection(AWSQueryConnection):
         :param rds_db_instance_arn: The Amazon RDS instance's ARN.
 
         :type db_user: string
-        :param db_user: The master user name.
+        :param db_user: The main user name.
 
         :type db_password: string
         :param db_password: The database password.

--- a/env/Lib/site-packages/boto/pyami/bootstrap.py
+++ b/env/Lib/site-packages/boto/pyami/bootstrap.py
@@ -88,7 +88,7 @@ class Bootstrap(ScriptBase):
             if update.find(':') >= 0:
                 method, version = update.split(':')
             else:
-                version = 'master'
+                version = 'main'
             self.run('git checkout %s' % version, cwd=location)
         else:
             # first remove the symlink needed when running from subversion

--- a/env/Lib/site-packages/boto/rds/__init__.py
+++ b/env/Lib/site-packages/boto/rds/__init__.py
@@ -138,8 +138,8 @@ class RDSConnection(AWSQueryConnection):
                           id,
                           allocated_storage,
                           instance_class,
-                          master_username,
-                          master_password,
+                          main_username,
+                          main_password,
                           port=3306,
                           engine='MySQL5.1',
                           db_name=None,
@@ -168,8 +168,8 @@ class RDSConnection(AWSQueryConnection):
         # security_groups should be db_security_groups according to API docs but has been left
         # security_groups for backwards compatibility
         #
-        # master_password should be master_user_password according to API docs but has been left
-        # master_password for backwards compatibility
+        # main_password should be main_user_password according to API docs but has been left
+        # main_password for backwards compatibility
         #
         # instance_class should be db_instance_class according to API docs but has been left
         # instance_class for backwards compatibility
@@ -222,8 +222,8 @@ class RDSConnection(AWSQueryConnection):
                        * sqlserver-web
                        * postgres
 
-        :type master_username: str
-        :param master_username: Name of master user for the DBInstance.
+        :type main_username: str
+        :param main_username: Name of main user for the DBInstance.
 
                                 * MySQL must be;
                                   - 1--16 alphanumeric characters
@@ -240,8 +240,8 @@ class RDSConnection(AWSQueryConnection):
                                   - first character must be a letter
                                   - cannot be a reserver SQL Server word
 
-        :type master_password: str
-        :param master_password: Password of master user for the DBInstance.
+        :type main_password: str
+        :param main_password: Password of main user for the DBInstance.
 
                                 * MySQL must be 8--41 alphanumeric characters
 
@@ -398,8 +398,8 @@ class RDSConnection(AWSQueryConnection):
         # engine => Engine
         # engine_version => EngineVersion
         # license_model => LicenseModel
-        # master_username => MasterUsername
-        # master_user_password => MasterUserPassword
+        # main_username => MainUsername
+        # main_user_password => MainUserPassword
         # multi_az => MultiAZ
         # option_group_name => OptionGroupName
         # port => Port
@@ -423,8 +423,8 @@ class RDSConnection(AWSQueryConnection):
                   'EngineVersion': engine_version,
                   'Iops': iops,
                   'LicenseModel': license_model,
-                  'MasterUsername': master_username,
-                  'MasterUserPassword': master_password,
+                  'MainUsername': main_username,
+                  'MainUserPassword': main_password,
                   'MultiAZ': str(multi_az).lower() if multi_az else None,
                   'OptionGroupName': option_group_name,
                   'Port': port,
@@ -562,7 +562,7 @@ class RDSConnection(AWSQueryConnection):
 
     def modify_dbinstance(self, id, param_group=None, security_groups=None,
                           preferred_maintenance_window=None,
-                          master_password=None, allocated_storage=None,
+                          main_password=None, allocated_storage=None,
                           instance_class=None,
                           backup_retention_period=None,
                           preferred_backup_window=None,
@@ -593,8 +593,8 @@ class RDSConnection(AWSQueryConnection):
                                              occur.
                                              Default is Sun:05:00-Sun:09:00
 
-        :type master_password: str
-        :param master_password: Password of master user for the DBInstance.
+        :type main_password: str
+        :param main_password: Password of main user for the DBInstance.
                                 Must be 4-15 alphanumeric characters.
 
         :type allocated_storage: int
@@ -680,8 +680,8 @@ class RDSConnection(AWSQueryConnection):
             self.build_list_params(params, l, 'VpcSecurityGroupIds.member')
         if preferred_maintenance_window:
             params['PreferredMaintenanceWindow'] = preferred_maintenance_window
-        if master_password:
-            params['MasterUserPassword'] = master_password
+        if main_password:
+            params['MainUserPassword'] = main_password
         if allocated_storage:
             params['AllocatedStorage'] = allocated_storage
         if instance_class:

--- a/env/Lib/site-packages/boto/rds/dbinstance.py
+++ b/env/Lib/site-packages/boto/rds/dbinstance.py
@@ -47,7 +47,7 @@ class DBInstance(object):
         in status "available".
     :ivar instance_class: Contains the name of the compute and memory
         capacity class of the DB Instance.
-    :ivar master_username: The username that is set as master username
+    :ivar main_username: The username that is set as main username
         at creation time.
     :ivar parameter_groups: Provides the list of DB Parameter Groups
         applied to this DB Instance.
@@ -98,7 +98,7 @@ class DBInstance(object):
         self.auto_minor_version_upgrade = None
         self.endpoint = None
         self.instance_class = None
-        self.master_username = None
+        self.main_username = None
         self.parameter_groups = []
         self.security_groups = []
         self.read_replica_dbinstance_identifiers = []
@@ -172,8 +172,8 @@ class DBInstance(object):
             self.auto_minor_version_upgrade = value.lower() == 'true'
         elif name == 'DBInstanceClass':
             self.instance_class = value
-        elif name == 'MasterUsername':
-            self.master_username = value
+        elif name == 'MainUsername':
+            self.main_username = value
         elif name == 'Port':
             if self._in_endpoint:
                 self._port = int(value)
@@ -293,7 +293,7 @@ class DBInstance(object):
 
     def modify(self, param_group=None, security_groups=None,
                preferred_maintenance_window=None,
-               master_password=None, allocated_storage=None,
+               main_password=None, allocated_storage=None,
                instance_class=None,
                backup_retention_period=None,
                preferred_backup_window=None,
@@ -318,8 +318,8 @@ class DBInstance(object):
             UTC) during which maintenance can occur.  Default is
             Sun:05:00-Sun:09:00
 
-        :type master_password: str
-        :param master_password: Password of master user for the DBInstance.
+        :type main_password: str
+        :param main_password: Password of main user for the DBInstance.
             Must be 4-15 alphanumeric characters.
 
         :type allocated_storage: int
@@ -386,7 +386,7 @@ class DBInstance(object):
                                                  param_group,
                                                  security_groups,
                                                  preferred_maintenance_window,
-                                                 master_password,
+                                                 main_password,
                                                  allocated_storage,
                                                  instance_class,
                                                  backup_retention_period,

--- a/env/Lib/site-packages/boto/rds/dbsnapshot.py
+++ b/env/Lib/site-packages/boto/rds/dbsnapshot.py
@@ -34,10 +34,10 @@ class DBSnapshot(object):
     :ivar id: Specifies the identifier for the DB Snapshot (DBSnapshotIdentifier)
     :ivar instance_create_time: Specifies the time (UTC) when the snapshot was taken
     :ivar instance_id: Specifies the the DBInstanceIdentifier of the DB Instance this DB Snapshot was created from (DBInstanceIdentifier)
-    :ivar master_username: Provides the master username for the DB Instance
+    :ivar main_username: Provides the main username for the DB Instance
     :ivar port: Specifies the port that the database engine was listening on at the time of the snapshot
     :ivar snapshot_create_time: Provides the time (UTC) when the snapshot was taken
-    :ivar status: Specifies the status of this DB Snapshot. Possible values are [ available, backing-up, creating, deleted, deleting, failed, modifying, rebooting, resetting-master-credentials ]
+    :ivar status: Specifies the status of this DB Snapshot. Possible values are [ available, backing-up, creating, deleted, deleting, failed, modifying, rebooting, resetting-main-credentials ]
     :ivar iops: Specifies the Provisioned IOPS (I/O operations per second) value of the DB instance at the time of the snapshot.
     :ivar option_group_name: Provides the option group name for the DB snapshot.
     :ivar percent_progress: The percentage of the estimated data that has been transferred.
@@ -56,7 +56,7 @@ class DBSnapshot(object):
         self.port = None
         self.status = None
         self.availability_zone = None
-        self.master_username = None
+        self.main_username = None
         self.allocated_storage = None
         self.instance_id = None
         self.availability_zone = None
@@ -93,8 +93,8 @@ class DBSnapshot(object):
             self.status = value
         elif name == 'AvailabilityZone':
             self.availability_zone = value
-        elif name == 'MasterUsername':
-            self.master_username = value
+        elif name == 'MainUsername':
+            self.main_username = value
         elif name == 'AllocatedStorage':
             self.allocated_storage = int(value)
         elif name == 'SnapshotTime':

--- a/env/Lib/site-packages/boto/rds2/layer1.py
+++ b/env/Lib/site-packages/boto/rds2/layer1.py
@@ -321,8 +321,8 @@ class RDSConnection(AWSQueryConnection):
             path='/', params=params)
 
     def create_db_instance(self, db_instance_identifier, allocated_storage,
-                           db_instance_class, engine, master_username,
-                           master_user_password, db_name=None,
+                           db_instance_class, engine, main_username,
+                           main_user_password, db_name=None,
                            db_security_groups=None,
                            vpc_security_group_ids=None,
                            availability_zone=None, db_subnet_group_name=None,
@@ -417,9 +417,9 @@ class RDSConnection(AWSQueryConnection):
         Valid Values: `MySQL` | `oracle-se1` | `oracle-se` | `oracle-ee` |
             `sqlserver-ee` | `sqlserver-se` | `sqlserver-ex` | `sqlserver-web`
 
-        :type master_username: string
-        :param master_username:
-        The name of master user for the client DB instance.
+        :type main_username: string
+        :param main_username:
+        The name of main user for the client DB instance.
 
         **MySQL**
 
@@ -452,8 +452,8 @@ class RDSConnection(AWSQueryConnection):
         + First character must be a letter.
         + Cannot be a reserved word for the chosen database engine.
 
-        :type master_user_password: string
-        :param master_user_password: The password for the master database user.
+        :type main_user_password: string
+        :param main_user_password: The password for the main database user.
             Can be any printable ASCII character except "/", '"', or "@".
         Type: String
 
@@ -536,7 +536,7 @@ class RDSConnection(AWSQueryConnection):
 
 
         + Must be a value from 0 to 8
-        + Cannot be set to 0 if the DB instance is a master instance with read
+        + Cannot be set to 0 if the DB instance is a main instance with read
               replicas
 
         :type preferred_backup_window: string
@@ -656,8 +656,8 @@ class RDSConnection(AWSQueryConnection):
             'AllocatedStorage': allocated_storage,
             'DBInstanceClass': db_instance_class,
             'Engine': engine,
-            'MasterUsername': master_username,
-            'MasterUserPassword': master_user_password,
+            'MainUsername': main_username,
+            'MainUserPassword': main_user_password,
         }
         if db_name is not None:
             params['DBName'] = db_name
@@ -2488,7 +2488,7 @@ class RDSConnection(AWSQueryConnection):
                            allocated_storage=None, db_instance_class=None,
                            db_security_groups=None,
                            vpc_security_group_ids=None,
-                           apply_immediately=None, master_user_password=None,
+                           apply_immediately=None, main_user_password=None,
                            db_parameter_group_name=None,
                            backup_retention_period=None,
                            preferred_backup_window=None,
@@ -2616,14 +2616,14 @@ class RDSConnection(AWSQueryConnection):
 
         Default: `False`
 
-        :type master_user_password: string
-        :param master_user_password:
-        The new password for the DB instance master user. Can be any printable
+        :type main_user_password: string
+        :param main_user_password:
+        The new password for the DB instance main user. Can be any printable
             ASCII character except "/", '"', or "@".
 
         Changing this parameter does not result in an outage and the change is
             asynchronously applied as soon as possible. Between the time of the
-            request and the completion of the request, the `MasterUserPassword`
+            request and the completion of the request, the `MainUserPassword`
             element exists in the `PendingModifiedValues` element of the
             operation response.
 
@@ -2634,7 +2634,7 @@ class RDSConnection(AWSQueryConnection):
             characters (SQL Server).
 
         Amazon RDS API actions never return the password, so this action
-            provides a way to regain access to a master instance user if the
+            provides a way to regain access to a main instance user if the
             password is lost.
 
         :type db_parameter_group_name: string
@@ -2668,7 +2668,7 @@ class RDSConnection(AWSQueryConnection):
 
 
         + Must be a value from 0 to 8
-        + Cannot be set to 0 if the DB instance is a master instance with read
+        + Cannot be set to 0 if the DB instance is a main instance with read
               replicas or if the DB instance is a read replica
 
         :type preferred_backup_window: string
@@ -2820,8 +2820,8 @@ class RDSConnection(AWSQueryConnection):
         if apply_immediately is not None:
             params['ApplyImmediately'] = str(
                 apply_immediately).lower()
-        if master_user_password is not None:
-            params['MasterUserPassword'] = master_user_password
+        if main_user_password is not None:
+            params['MainUserPassword'] = main_user_password
         if db_parameter_group_name is not None:
             params['DBParameterGroupName'] = db_parameter_group_name
         if backup_retention_period is not None:

--- a/env/Lib/site-packages/boto/redshift/layer1.py
+++ b/env/Lib/site-packages/boto/redshift/layer1.py
@@ -310,8 +310,8 @@ class RedshiftConnection(AWSQueryConnection):
             verb='POST',
             path='/', params=params)
 
-    def create_cluster(self, cluster_identifier, node_type, master_username,
-                       master_user_password, db_name=None, cluster_type=None,
+    def create_cluster(self, cluster_identifier, node_type, main_username,
+                       main_user_password, db_name=None, cluster_type=None,
                        cluster_security_groups=None,
                        vpc_security_group_ids=None,
                        cluster_subnet_group_name=None,
@@ -391,9 +391,9 @@ class RedshiftConnection(AWSQueryConnection):
         Valid Values: `dw1.xlarge` | `dw1.8xlarge` | `dw2.large` |
             `dw2.8xlarge`.
 
-        :type master_username: string
-        :param master_username:
-        The user name associated with the master user account for the cluster
+        :type main_username: string
+        :param main_username:
+        The user name associated with the main user account for the cluster
             that is being created.
 
         Constraints:
@@ -404,9 +404,9 @@ class RedshiftConnection(AWSQueryConnection):
         + Cannot be a reserved word. A list of reserved words can be found in
               `Reserved Words`_ in the Amazon Redshift Database Developer Guide.
 
-        :type master_user_password: string
-        :param master_user_password:
-        The password associated with the master user account for the cluster
+        :type main_user_password: string
+        :param main_user_password:
+        The password associated with the main user account for the cluster
             that is being created.
 
         Constraints:
@@ -573,8 +573,8 @@ class RedshiftConnection(AWSQueryConnection):
         params = {
             'ClusterIdentifier': cluster_identifier,
             'NodeType': node_type,
-            'MasterUsername': master_username,
-            'MasterUserPassword': master_user_password,
+            'MainUsername': main_username,
+            'MainUserPassword': main_user_password,
         }
         if db_name is not None:
             params['DBName'] = db_name
@@ -2253,7 +2253,7 @@ class RedshiftConnection(AWSQueryConnection):
                        node_type=None, number_of_nodes=None,
                        cluster_security_groups=None,
                        vpc_security_group_ids=None,
-                       master_user_password=None,
+                       main_user_password=None,
                        cluster_parameter_group_name=None,
                        automated_snapshot_retention_period=None,
                        preferred_maintenance_window=None,
@@ -2264,7 +2264,7 @@ class RedshiftConnection(AWSQueryConnection):
         """
         Modifies the settings for a cluster. For example, you can add
         another security or parameter group, update the preferred
-        maintenance window, or change the master user password.
+        maintenance window, or change the main user password.
         Resetting a cluster password or modifying the security groups
         associated with a cluster do not need a reboot. However,
         modifying a parameter group requires a reboot for parameters
@@ -2345,11 +2345,11 @@ class RedshiftConnection(AWSQueryConnection):
         :param vpc_security_group_ids: A list of virtual private cloud (VPC)
             security groups to be associated with the cluster.
 
-        :type master_user_password: string
-        :param master_user_password:
-        The new password for the cluster master user. This change is
+        :type main_user_password: string
+        :param main_user_password:
+        The new password for the cluster main user. This change is
             asynchronously applied as soon as possible. Between the time of the
-            request and the completion of the request, the `MasterUserPassword`
+            request and the completion of the request, the `MainUserPassword`
             element exists in the `PendingModifiedValues` element of the
             operation response.
 
@@ -2464,8 +2464,8 @@ class RedshiftConnection(AWSQueryConnection):
             self.build_list_params(params,
                                    vpc_security_group_ids,
                                    'VpcSecurityGroupIds.member')
-        if master_user_password is not None:
-            params['MasterUserPassword'] = master_user_password
+        if main_user_password is not None:
+            params['MainUserPassword'] = main_user_password
         if cluster_parameter_group_name is not None:
             params['ClusterParameterGroupName'] = cluster_parameter_group_name
         if automated_snapshot_retention_period is not None:

--- a/env/Lib/site-packages/django/apps/registry.py
+++ b/env/Lib/site-packages/django/apps/registry.py
@@ -18,7 +18,7 @@ class Apps(object):
     """
 
     def __init__(self, installed_apps=()):
-        # installed_apps is set to None when creating the master registry
+        # installed_apps is set to None when creating the main registry
         # because it cannot be populated at that point. Other registries must
         # provide a list of installed apps and are populated immediately.
         if installed_apps is None and hasattr(sys.modules[__name__], 'apps'):
@@ -51,7 +51,7 @@ class Apps(object):
         # `lazy_model_operation()` and `do_pending_operations()` methods.
         self._pending_operations = defaultdict(list)
 
-        # Populate apps and models, unless it's the master registry.
+        # Populate apps and models, unless it's the main registry.
         if installed_apps is not None:
             self.populate(installed_apps)
 

--- a/env/Lib/site-packages/django/conf/global_settings.py
+++ b/env/Lib/site-packages/django/conf/global_settings.py
@@ -221,7 +221,7 @@ FORM_RENDERER = 'django.forms.renderers.DjangoTemplates'
 
 # Default email address to use for various automated correspondence from
 # the site managers.
-DEFAULT_FROM_EMAIL = 'webmaster@localhost'
+DEFAULT_FROM_EMAIL = 'webmain@localhost'
 
 # Subject-line prefix for email messages send with django.core.mail.mail_admins
 # or ...mail_managers.  Make sure to include the trailing space.

--- a/env/Lib/site-packages/django/db/backends/sqlite3/introspection.py
+++ b/env/Lib/site-packages/django/db/backends/sqlite3/introspection.py
@@ -64,7 +64,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         # Skip the sqlite_sequence system table used for autoincrement key
         # generation.
         cursor.execute("""
-            SELECT name, type FROM sqlite_master
+            SELECT name, type FROM sqlite_main
             WHERE type in ('table', 'view') AND NOT name='sqlite_sequence'
             ORDER BY name""")
         return [TableInfo(row[0], row[1][0]) for row in cursor.fetchall()]
@@ -108,7 +108,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         relations = {}
 
         # Schema for this table
-        cursor.execute("SELECT sql FROM sqlite_master WHERE tbl_name = %s AND type = %s", [table_name, "table"])
+        cursor.execute("SELECT sql FROM sqlite_main WHERE tbl_name = %s AND type = %s", [table_name, "table"])
         try:
             results = cursor.fetchone()[0].strip()
         except TypeError:
@@ -136,7 +136,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
             else:
                 field_name = field_desc.split()[0].strip('"')
 
-            cursor.execute("SELECT sql FROM sqlite_master WHERE tbl_name = %s", [table])
+            cursor.execute("SELECT sql FROM sqlite_main WHERE tbl_name = %s", [table])
             result = cursor.fetchall()[0]
             other_table_results = result[0].strip()
             li, ri = other_table_results.index('('), other_table_results.rindex(')')
@@ -162,7 +162,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         key_columns = []
 
         # Schema for this table
-        cursor.execute("SELECT sql FROM sqlite_master WHERE tbl_name = %s AND type = %s", [table_name, "table"])
+        cursor.execute("SELECT sql FROM sqlite_main WHERE tbl_name = %s AND type = %s", [table_name, "table"])
         results = cursor.fetchone()[0].strip()
         results = results[results.index('(') + 1:results.rindex(')')]
 
@@ -211,7 +211,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         Get the column name of the primary key for the given table.
         """
         # Don't use PRAGMA because that causes issues with some transactions
-        cursor.execute("SELECT sql FROM sqlite_master WHERE tbl_name = %s AND type = %s", [table_name, "table"])
+        cursor.execute("SELECT sql FROM sqlite_main WHERE tbl_name = %s AND type = %s", [table_name, "table"])
         row = cursor.fetchone()
         if row is None:
             raise ValueError("Table %s does not exist" % table_name)
@@ -265,7 +265,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
                 # SQLite doesn't support any index type other than b-tree
                 constraints[index]['type'] = Index.suffix
                 cursor.execute(
-                    "SELECT sql FROM sqlite_master "
+                    "SELECT sql FROM sqlite_main "
                     "WHERE type='index' AND name=%s" % self.connection.ops.quote_name(index)
                 )
                 orders = []

--- a/env/Lib/site-packages/django/test/client.py
+++ b/env/Lib/site-packages/django/test/client.py
@@ -462,7 +462,7 @@ class Client(RequestFactory):
 
     def request(self, **request):
         """
-        The master request method. Composes the environment dictionary
+        The main request method. Composes the environment dictionary
         and passes to the handler, returning the result of the handler.
         Assumes defaults for the query environment, which can be overridden
         using the arguments to the request.

--- a/env/Lib/site-packages/django/test/runner.py
+++ b/env/Lib/site-packages/django/test/runner.py
@@ -71,7 +71,7 @@ class RemoteTestResult(object):
     Record information about which tests have succeeded and which have failed.
 
     The sole purpose of this class is to record events in the child processes
-    so they can be replayed in the master process. As a consequence it doesn't
+    so they can be replayed in the main process. As a consequence it doesn't
     inherit unittest.TestResult and doesn't attempt to implement all its API.
 
     The implementation matches the unpythonic coding style of unittest2.

--- a/env/Lib/site-packages/docutils/parsers/rst/states.py
+++ b/env/Lib/site-packages/docutils/parsers/rst/states.py
@@ -137,7 +137,7 @@ class Struct:
 class RSTStateMachine(StateMachineWS):
 
     """
-    reStructuredText's master StateMachine.
+    reStructuredText's main StateMachine.
 
     The entry point to reStructuredText parsing is the `run()` method.
     """

--- a/env/Lib/site-packages/docutils/parsers/rst/tableparser.py
+++ b/env/Lib/site-packages/docutils/parsers/rst/tableparser.py
@@ -534,11 +534,11 @@ class SimpleTableParser(TableParser):
                 self.table[first_body_row:])
 
 
-def update_dict_of_lists(master, newdata):
+def update_dict_of_lists(main, newdata):
     """
-    Extend the list values of `master` with those from `newdata`.
+    Extend the list values of `main` with those from `newdata`.
 
     Both parameters must be dictionaries containing list values.
     """
     for key, values in list(newdata.items()):
-        master.setdefault(key, []).extend(values)
+        main.setdefault(key, []).extend(values)

--- a/env/Lib/site-packages/docutils/utils/math/math2html.py
+++ b/env/Lib/site-packages/docutils/utils/math/math2html.py
@@ -114,7 +114,7 @@ class BibStylesConfig(object):
       '@incollection':'$authors: <i>$title</i>{ in <i>$booktitle</i>{ ($editor, ed.)}}.{{ $publisher,} $year.}{ URL <a href="$url">$url</a>.}{ $note.}', 
       '@inproceedings':'$authors: “$title”, <i>$booktitle</i>,{ pp. $pages,} $year.{ URL <a href="$url">$url</a>.}{ $note.}', 
       '@manual':'$authors: <i>$title</i>.{{ $publisher,} $year.}{ URL <a href="$url">$url</a>.}{ $note.}', 
-      '@mastersthesis':'$authors: <i>$title</i>.{{ $publisher,} $year.}{ URL <a href="$url">$url</a>.}{ $note.}', 
+      '@mainsthesis':'$authors: <i>$title</i>.{{ $publisher,} $year.}{ URL <a href="$url">$url</a>.}{ $note.}', 
       '@misc':'$authors: <i>$title</i>.{{ $publisher,}{ $howpublished,} $year.}{ URL <a href="$url">$url</a>.}{ $note.}', 
       '@phdthesis':'$authors: <i>$title</i>.{{ $publisher,} $year.}{ URL <a href="$url">$url</a>.}{ $note.}', 
       '@proceedings':'$authors: “$title”, <i>$journal</i>,{ pp. $pages,} $year.{ URL <a href="$url">$url</a>.}{ $note.}', 
@@ -3177,7 +3177,7 @@ class NumberCounter(object):
   name = None
   value = None
   mode = None
-  master = None
+  main = None
 
   letters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
   symbols = NumberingConfig.sequence['symbols']
@@ -3260,25 +3260,25 @@ class NumberCounter(object):
     return result
 
 class DependentCounter(NumberCounter):
-  "A counter which depends on another one (the master)."
+  "A counter which depends on another one (the main)."
 
-  def setmaster(self, master):
-    "Set the master counter."
-    self.master = master
-    self.last = self.master.getvalue()
+  def setmain(self, main):
+    "Set the main counter."
+    self.main = main
+    self.last = self.main.getvalue()
     return self
 
   def getnext(self):
-    "Increase or, if the master counter has changed, restart."
-    if self.last != self.master.getvalue():
+    "Increase or, if the main counter has changed, restart."
+    if self.last != self.main.getvalue():
       self.reset()
     value = NumberCounter.getnext(self)
-    self.last = self.master.getvalue()
+    self.last = self.main.getvalue()
     return value
 
   def getvalue(self):
-    "Get the value of the combined counter: master.dependent."
-    return self.master.getvalue() + '.' + NumberCounter.getvalue(self)
+    "Get the value of the combined counter: main.dependent."
+    return self.main.getvalue() + '.' + NumberCounter.getvalue(self)
 
 class NumberGenerator(object):
   "A number generator for unique sequences and hierarchical structures. Used in:"
@@ -3366,22 +3366,22 @@ class NumberGenerator(object):
     if self.isnumbered(type) and self.getlevel(type) > 1:
       index = self.orderedlayouts.index(type)
       above = self.orderedlayouts[index - 1]
-      master = self.getcounter(above)
-      return self.createdependent(type, master)
+      main = self.getcounter(above)
+      return self.createdependent(type, main)
     counter = NumberCounter(type)
     if self.isroman(type):
       counter.setmode('I')
     return counter
 
-  def getdependentcounter(self, type, master):
+  def getdependentcounter(self, type, main):
     "Get (or create) a counter of the given type that depends on another."
-    if not type in self.counters or not self.counters[type].master:
-      self.counters[type] = self.createdependent(type, master)
+    if not type in self.counters or not self.counters[type].main:
+      self.counters[type] = self.createdependent(type, main)
     return self.counters[type]
 
-  def createdependent(self, type, master):
-    "Create a dependent counter given the master."
-    return DependentCounter(type).setmaster(master)
+  def createdependent(self, type, main):
+    "Create a dependent counter given the main."
+    return DependentCounter(type).setmain(main)
 
   def startappendix(self):
     "Start appendices here."

--- a/env/Lib/site-packages/docutils/writers/odf_odt/__init__.py
+++ b/env/Lib/site-packages/docutils/writers/odf_odt/__init__.py
@@ -1082,7 +1082,7 @@ class ODFTranslator(nodes.GenericNodeVisitor):
         el1 = SubElement(
             self.automatic_styles, 'style:style', attrib={
                 'style:name': style_name,
-                'style:master-page-name': "rststyle-pagedefault",
+                'style:main-page-name': "rststyle-pagedefault",
                 'style:family': "paragraph",
             }, nsdict=SNSD)
         if current_style:
@@ -1140,22 +1140,22 @@ class ODFTranslator(nodes.GenericNodeVisitor):
     def add_header_footer(self, root_el):
         automatic_styles = root_el.find(
             '{%s}automatic-styles' % SNSD['office'])
-        path = '{%s}master-styles' % (NAME_SPACE_1, )
-        master_el = root_el.find(path)
-        if master_el is None:
+        path = '{%s}main-styles' % (NAME_SPACE_1, )
+        main_el = root_el.find(path)
+        if main_el is None:
             return
-        path = '{%s}master-page' % (SNSD['style'], )
-        master_el_container = master_el.findall(path)
-        master_el = None
+        path = '{%s}main-page' % (SNSD['style'], )
+        main_el_container = main_el.findall(path)
+        main_el = None
         target_attrib = '{%s}name' % (SNSD['style'], )
         target_name = self.rststyle('pagedefault')
-        for el in master_el_container:
+        for el in main_el_container:
             if el.get(target_attrib) == target_name:
-                master_el = el
+                main_el = el
                 break
-        if master_el is None:
+        if main_el is None:
             return
-        el1 = master_el
+        el1 = main_el
         if self.header_content or self.settings.custom_header:
             if WhichElementTree == 'lxml':
                 el2 = SubElement(el1, 'style:header', nsdict=SNSD)

--- a/env/Lib/site-packages/pip/_vendor/pkg_resources/__init__.py
+++ b/env/Lib/site-packages/pip/_vendor/pkg_resources/__init__.py
@@ -644,9 +644,9 @@ class WorkingSet(object):
             self.add_entry(entry)
 
     @classmethod
-    def _build_master(cls):
+    def _build_main(cls):
         """
-        Prepare the master working set.
+        Prepare the main working set.
         """
         ws = cls()
         try:
@@ -3016,9 +3016,9 @@ def _initialize(g=globals()):
 
 
 @_call_aside
-def _initialize_master_working_set():
+def _initialize_main_working_set():
     """
-    Prepare the master working set and make the ``require()``
+    Prepare the main working set and make the ``require()``
     API available.
 
     This function has explicit effects on the global state
@@ -3028,7 +3028,7 @@ def _initialize_master_working_set():
     Invocation by other packages is unsupported and done
     at their own risk.
     """
-    working_set = WorkingSet._build_master()
+    working_set = WorkingSet._build_main()
     _declare_state('object', working_set=working_set)
 
     require = working_set.require

--- a/env/Lib/site-packages/pip/vcs/git.py
+++ b/env/Lib/site-packages/pip/vcs/git.py
@@ -118,7 +118,7 @@ class Git(VersionControl):
             self.run_command(['fetch', '-q', '--tags'], cwd=dest)
         else:
             self.run_command(['fetch', '-q'], cwd=dest)
-        # Then reset to wanted revision (maybe even origin/master)
+        # Then reset to wanted revision (maybe even origin/main)
         if rev_options:
             rev_options = self.check_rev_options(
                 rev_options[0], dest, rev_options,
@@ -133,7 +133,7 @@ class Git(VersionControl):
             rev_options = [rev]
             rev_display = ' (to %s)' % rev
         else:
-            rev_options = ['origin/master']
+            rev_options = ['origin/main']
             rev_display = ''
         if self.check_destination(dest, url, rev_options, rev_display):
             logger.info(

--- a/env/Lib/site-packages/pkg_resources/__init__.py
+++ b/env/Lib/site-packages/pkg_resources/__init__.py
@@ -648,9 +648,9 @@ class WorkingSet(object):
             self.add_entry(entry)
 
     @classmethod
-    def _build_master(cls):
+    def _build_main(cls):
         """
-        Prepare the master working set.
+        Prepare the main working set.
         """
         ws = cls()
         try:
@@ -3072,9 +3072,9 @@ def _initialize(g=globals()):
 
 
 @_call_aside
-def _initialize_master_working_set():
+def _initialize_main_working_set():
     """
-    Prepare the master working set and make the ``require()``
+    Prepare the main working set and make the ``require()``
     API available.
 
     This function has explicit effects on the global state
@@ -3084,7 +3084,7 @@ def _initialize_master_working_set():
     Invocation by other packages is unsupported and done
     at their own risk.
     """
-    working_set = WorkingSet._build_master()
+    working_set = WorkingSet._build_main()
     _declare_state('object', working_set=working_set)
 
     require = working_set.require

--- a/env/Lib/site-packages/setuptools/command/easy_install.py
+++ b/env/Lib/site-packages/setuptools/command/easy_install.py
@@ -1742,7 +1742,7 @@ def update_dist_caches(dist_path, fix_zipimporter_caches):
     # There are several other known sources of stale zipimport.zipimporter
     # instances that we do not clear here, but might if ever given a reason to
     # do so:
-    # * Global setuptools pkg_resources.working_set (a.k.a. 'master working
+    # * Global setuptools pkg_resources.working_set (a.k.a. 'main working
     # set') may contain distributions which may in turn contain their
     #   zipimport.zipimporter loaders.
     # * Several zipimport.zipimporter loaders held by local variables further

--- a/env/Lib/site-packages/stem/descriptor/extrainfo_descriptor.py
+++ b/env/Lib/site-packages/stem/descriptor/extrainfo_descriptor.py
@@ -536,7 +536,7 @@ def _parse_hs_stats(keyword, stat_attribute, extra_attribute, descriptor, entrie
 
 
 _parse_identity_ed25519_line = _parse_key_block('identity-ed25519', 'ed25519_certificate', 'ED25519 CERT')
-_parse_master_key_ed25519_line = _parse_simple_line('master-key-ed25519', 'ed25519_certificate_hash')
+_parse_main_key_ed25519_line = _parse_simple_line('main-key-ed25519', 'ed25519_certificate_hash')
 _parse_geoip_db_digest_line = _parse_forty_character_hex('geoip-db-digest', 'geoip_db_digest')
 _parse_geoip6_db_digest_line = _parse_forty_character_hex('geoip6-db-digest', 'geoip6_db_digest')
 _parse_dirreq_v2_resp_line = functools.partial(_parse_dirreq_line, 'dirreq-v2-resp', 'dir_v2_responses', 'dir_v2_responses_unknown')
@@ -935,13 +935,13 @@ class BridgeExtraInfoDescriptor(ExtraInfoDescriptor):
   """
 
   ATTRIBUTES = dict(ExtraInfoDescriptor.ATTRIBUTES, **{
-    'ed25519_certificate_hash': (None, _parse_master_key_ed25519_line),
+    'ed25519_certificate_hash': (None, _parse_main_key_ed25519_line),
     'router_digest_sha256': (None, _parse_router_digest_sha256_line),
     '_digest': (None, _parse_router_digest_line),
   })
 
   PARSER_FOR_LINE = dict(ExtraInfoDescriptor.PARSER_FOR_LINE, **{
-    'master-key-ed25519': _parse_master_key_ed25519_line,
+    'main-key-ed25519': _parse_main_key_ed25519_line,
     'router-digest-sha256': _parse_router_digest_sha256_line,
     'router-digest': _parse_router_digest_line,
   })

--- a/env/Lib/site-packages/stem/descriptor/server_descriptor.py
+++ b/env/Lib/site-packages/stem/descriptor/server_descriptor.py
@@ -80,7 +80,7 @@ REQUIRED_FIELDS = (
 # optional entries that can appear at most once
 SINGLE_FIELDS = (
   'identity-ed25519',
-  'master-key-ed25519',
+  'main-key-ed25519',
   'platform',
   'fingerprint',
   'hibernating',
@@ -385,8 +385,8 @@ def _parse_exit_policy(descriptor, entries):
 
 
 _parse_identity_ed25519_line = _parse_key_block('identity-ed25519', 'ed25519_certificate', 'ED25519 CERT')
-_parse_master_key_ed25519_line = _parse_simple_line('master-key-ed25519', 'ed25519_master_key')
-_parse_master_key_ed25519_for_hash_line = _parse_simple_line('master-key-ed25519', 'ed25519_certificate_hash')
+_parse_main_key_ed25519_line = _parse_simple_line('main-key-ed25519', 'ed25519_main_key')
+_parse_main_key_ed25519_for_hash_line = _parse_simple_line('main-key-ed25519', 'ed25519_certificate_hash')
 _parse_contact_line = _parse_bytes_line('contact', 'contact')
 _parse_published_line = _parse_timestamp_line('published', 'published')
 _parse_read_history_line = functools.partial(_parse_history_line, 'read-history', 'read_history_end', 'read_history_interval', 'read_history_values')
@@ -678,7 +678,7 @@ class RelayDescriptor(ServerDescriptor):
   <https://gitweb.torproject.org/torspec.git/tree/dir-spec.txt>`_)
 
   :var str ed25519_certificate: base64 encoded ed25519 certificate
-  :var str ed25519_master_key: base64 encoded master key for our ed25519 certificate
+  :var str ed25519_main_key: base64 encoded main key for our ed25519 certificate
   :var str ed25519_signature: signature of this document using ed25519
 
   :var str onion_key: **\*** key used to encrypt EXTEND cells
@@ -691,14 +691,14 @@ class RelayDescriptor(ServerDescriptor):
   **\*** attribute is required when we're parsed with validation
 
   .. versionchanged:: 1.5.0
-     Added the ed25519_certificate, ed25519_master_key, ed25519_signature,
+     Added the ed25519_certificate, ed25519_main_key, ed25519_signature,
      onion_key_crosscert, ntor_onion_key_crosscert, and
      ntor_onion_key_crosscert_sign attributes.
   """
 
   ATTRIBUTES = dict(ServerDescriptor.ATTRIBUTES, **{
     'ed25519_certificate': (None, _parse_identity_ed25519_line),
-    'ed25519_master_key': (None, _parse_master_key_ed25519_line),
+    'ed25519_main_key': (None, _parse_main_key_ed25519_line),
     'ed25519_signature': (None, _parse_router_sig_ed25519_line),
 
     'onion_key': (None, _parse_onion_key_line),
@@ -711,7 +711,7 @@ class RelayDescriptor(ServerDescriptor):
 
   PARSER_FOR_LINE = dict(ServerDescriptor.PARSER_FOR_LINE, **{
     'identity-ed25519': _parse_identity_ed25519_line,
-    'master-key-ed25519': _parse_master_key_ed25519_line,
+    'main-key-ed25519': _parse_main_key_ed25519_line,
     'router-sig-ed25519': _parse_router_sig_ed25519_line,
     'onion-key': _parse_onion_key_line,
     'onion-key-crosscert': _parse_onion_key_crosscert_line,
@@ -794,13 +794,13 @@ class BridgeDescriptor(ServerDescriptor):
   """
 
   ATTRIBUTES = dict(ServerDescriptor.ATTRIBUTES, **{
-    'ed25519_certificate_hash': (None, _parse_master_key_ed25519_for_hash_line),
+    'ed25519_certificate_hash': (None, _parse_main_key_ed25519_for_hash_line),
     'router_digest_sha256': (None, _parse_router_digest_sha256_line),
     '_digest': (None, _parse_router_digest_line),
   })
 
   PARSER_FOR_LINE = dict(ServerDescriptor.PARSER_FOR_LINE, **{
-    'master-key-ed25519': _parse_master_key_ed25519_for_hash_line,
+    'main-key-ed25519': _parse_main_key_ed25519_for_hash_line,
     'router-digest-sha256': _parse_router_digest_sha256_line,
     'router-digest': _parse_router_digest_line,
   })

--- a/env/Lib/site-packages/tqdm/_version.py
+++ b/env/Lib/site-packages/tqdm/_version.py
@@ -40,7 +40,7 @@ if os.path.isdir(gitdir):  # pragma: nocover
                     with io_open(ref_file_path, 'r') as fh_branch:
                         commit_hash = fh_branch.readline().strip()
                         extra = commit_hash[:8]
-                        if branch_name != "master":
+                        if branch_name != "main":
                             extra += '.' + branch_name
 
             # detached HEAD mode, already have commit hash

--- a/env/Lib/sre_parse.py
+++ b/env/Lib/sre_parse.py
@@ -72,7 +72,7 @@ class Verbose(Exception):
     pass
 
 class Pattern:
-    # master pattern object.  keeps track of global attributes
+    # main pattern object.  keeps track of global attributes
     def __init__(self):
         self.flags = 0
         self.groupdict = {}


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.